### PR TITLE
Fix dataset worker initialization bug

### DIFF
--- a/latentsync/data/syncnet_dataset.py
+++ b/latentsync/data/syncnet_dataset.py
@@ -49,6 +49,10 @@ class SyncNetDataset(Dataset):
         self.audio_mel_cache_dir = config.data.audio_mel_cache_dir
         os.makedirs(self.audio_mel_cache_dir, exist_ok=True)
 
+        # ``worker_init_fn`` is not executed when ``num_workers=0``.  Initialize
+        # ``worker_id`` here so that single-worker dataloaders work as well.
+        self.worker_id = 0
+
     def __len__(self):
         return len(self.video_paths)
 


### PR DESCRIPTION
## Summary
- handle `num_workers=0` by setting `worker_id` defaults for SyncNet and UNet datasets

## Testing
- `python -m py_compile $(git ls-files '*.py')`